### PR TITLE
155 | Show RSN in rank updates message in case the Discord user is unknown

### DIFF
--- a/helpers/calculateCabbages.ts
+++ b/helpers/calculateCabbages.ts
@@ -20,13 +20,13 @@ export const getCabbageBreakdown = (
     });
 
     const cabbageBreakdown = {
-        eventCabbages: memberData.eventCabbages,
+        eventCabbages: memberData.eventCabbages || 0,
         max: account.max ? configCabbages.max : 0,
         inferno: account.inferno ? configCabbages.inferno : 0,
         quiver: account.quiver ? configCabbages.quiver : 0,
         blorva: account.blorva ? configCabbages.blorva : 0,
         questCape: account.questCape ? configCabbages.questCape : 0,
-        clogSlots: clogCabbages,
+        clogSlots: clogCabbages || 0,
         caTier: configCabbages.ca[account.caTier] || 0,
         adTier: configCabbages.ad[account.adTier] || 0,
     } as { [key: string]: number };
@@ -40,6 +40,7 @@ export const getCabbageBreakdown = (
         playerDetails === undefined
             ? memberData.currentCabbages - sum
             : playerDetails.ehp + playerDetails.ehb;
+
     cabbageBreakdown.core = Math.floor(cabbageBreakdown.core);
     return cabbageBreakdown;
 };

--- a/helpers/updateMemberRank.test.ts
+++ b/helpers/updateMemberRank.test.ts
@@ -253,4 +253,42 @@ describe('helpers | updateMemberRank', () => {
             accountProgression: { clogSlots: 453 },
         });
     });
+
+    test('When a user has a display name set on WOM, then this name is referenced in the rank updates message', async () => {
+        // Arrange
+        const RSN = faker.person.fullName();
+
+        const rankUpdatesChannelMock = {
+            send: jest.fn(),
+        };
+
+        (discordClient.channels.cache.get as jest.Mock).mockReturnValue(
+            rankUpdatesChannelMock
+        );
+
+        TestHelper.userHasAccountInfo({
+            currentCabbages: 0,
+            eventCabbages: 0,
+            currentRank: 'Jade',
+            accountProgression: {},
+        });
+
+        TestHelper.userHasWOMData({
+            displayName: RSN,
+            ehp: 500,
+            ehb: 500,
+        });
+
+        // Act
+        await updateMemberRank(memberDiscordId, discordClient);
+
+        // Assert
+        expect(rankUpdatesChannelMock.send).toHaveBeenCalledWith(
+            expect.objectContaining({
+                content: expect.stringContaining(
+                    `(RSN: \`${RSN}\`) needs their rank in game updated to:`
+                ),
+            })
+        );
+    });
 });

--- a/helpers/updateMemberRank.ts
+++ b/helpers/updateMemberRank.ts
@@ -119,8 +119,11 @@ export const updateMemberRank = async (
             Environment.RANK_UPDATES_CHANNEL
         ) as TextChannel;
 
+        const RSN =
+            playerDetails.displayName || playerDetails.username || 'unknown';
+
         rankUpdatesChannel.send({
-            content: `<@${memberData.discordID}> needs their rank in game updated to: ${newRank}`,
+            content: `<@${memberData.discordID}> (RSN: \`${RSN}\`) needs their rank in game updated to: ${newRank}`,
             components: [row],
         });
     }


### PR DESCRIPTION
This happens when a registered user has left the Discord clan, but is still playing